### PR TITLE
guillaume/tas 178 fix types declaration in packagejson

### DIFF
--- a/bin/build.cjs
+++ b/bin/build.cjs
@@ -14,9 +14,9 @@ const TYPES_ICONS_DIR = path.join(TYPES_DIR, "icons");
 const ASSETS_SVG_DIR = path.join(ASSETS_DIR, "svg");
 const SRC_ICONS_DIR = path.join(SRC_DIR, "icons");
 
-fs.mkdir(TYPES_DIR, () => {});
-fs.mkdir(TYPES_ICONS_DIR, () => {});
-fs.mkdir(SRC_ICONS_DIR, () => {});
+fs.mkdirSync(TYPES_DIR, () => {});
+fs.mkdirSync(TYPES_ICONS_DIR, () => {});
+fs.mkdirSync(SRC_ICONS_DIR, () => {});
 
 const iconExports = [];
 const iconTypeExports = [];

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "format:local": "prettier --config package.json --ignore-path .prettierignore --write .",
     "format:ci": "prettier --config package.json --ignore-path .prettierignore --check .",
     "clean": "del-cli lib",
-    "prepare": "bunx tsc --project tsconfig.build.json && bun run bin/build-package.cjs",
+    "prepare": "tsc --project tsconfig.build.json && bun run bin/build-package.cjs",
     "release": "release-it"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "format:local": "prettier --config package.json --ignore-path .prettierignore --write .",
     "format:ci": "prettier --config package.json --ignore-path .prettierignore --check .",
     "clean": "del-cli lib",
-    "prepare": "tsc --project tsconfig.build.json && bun run bin/build-package.cjs",
+    "prepare": "bunx tsc --project tsconfig.build.json && bun run bin/build-package.cjs",
     "release": "release-it"
   },
   "keywords": [

--- a/src/icons/air.tsx
+++ b/src/icons/air.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/airplay-audio.tsx
+++ b/src/icons/airplay-audio.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/airplay-video.tsx
+++ b/src/icons/airplay-video.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/airpods.tsx
+++ b/src/icons/airpods.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/alarm.tsx
+++ b/src/icons/alarm.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/align-bottom.tsx
+++ b/src/icons/align-bottom.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/align-horizontal-center.tsx
+++ b/src/icons/align-horizontal-center.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/align-left.tsx
+++ b/src/icons/align-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/align-right.tsx
+++ b/src/icons/align-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/align-to-bottom.tsx
+++ b/src/icons/align-to-bottom.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/align-to-middle.tsx
+++ b/src/icons/align-to-middle.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/align-to-top.tsx
+++ b/src/icons/align-to-top.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/align-top.tsx
+++ b/src/icons/align-top.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/align-vertical-center.tsx
+++ b/src/icons/align-vertical-center.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/android-fill.tsx
+++ b/src/icons/android-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/angular-fill.tsx
+++ b/src/icons/angular-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-back-thick-fill.tsx
+++ b/src/icons/arrow-back-thick-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-back-thick.tsx
+++ b/src/icons/arrow-back-thick.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-back.tsx
+++ b/src/icons/arrow-back.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-clockwise.tsx
+++ b/src/icons/arrow-clockwise.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-counter-clockwise.tsx
+++ b/src/icons/arrow-counter-clockwise.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-cycle.tsx
+++ b/src/icons/arrow-cycle.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-down-left.tsx
+++ b/src/icons/arrow-down-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-down-right.tsx
+++ b/src/icons/arrow-down-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-down-thick.tsx
+++ b/src/icons/arrow-down-thick.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-down.tsx
+++ b/src/icons/arrow-down.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-forward-thick-fill.tsx
+++ b/src/icons/arrow-forward-thick-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-forward-thick.tsx
+++ b/src/icons/arrow-forward-thick.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-forward.tsx
+++ b/src/icons/arrow-forward.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-left-thick.tsx
+++ b/src/icons/arrow-left-thick.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-left.tsx
+++ b/src/icons/arrow-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-repeat.tsx
+++ b/src/icons/arrow-repeat.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-right-left.tsx
+++ b/src/icons/arrow-right-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-right-thick.tsx
+++ b/src/icons/arrow-right-thick.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-right.tsx
+++ b/src/icons/arrow-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-shuffle.tsx
+++ b/src/icons/arrow-shuffle.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-up-down.tsx
+++ b/src/icons/arrow-up-down.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-up-left.tsx
+++ b/src/icons/arrow-up-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-up-right.tsx
+++ b/src/icons/arrow-up-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-up-thick.tsx
+++ b/src/icons/arrow-up-thick.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/arrow-up.tsx
+++ b/src/icons/arrow-up.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/ascending.tsx
+++ b/src/icons/ascending.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/attach.tsx
+++ b/src/icons/attach.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/augmented-reality.tsx
+++ b/src/icons/augmented-reality.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/backspace-fill.tsx
+++ b/src/icons/backspace-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/backspace.tsx
+++ b/src/icons/backspace.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/bank.tsx
+++ b/src/icons/bank.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/basket.tsx
+++ b/src/icons/basket.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/battery-charging.tsx
+++ b/src/icons/battery-charging.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/battery-empty.tsx
+++ b/src/icons/battery-empty.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/battery-full.tsx
+++ b/src/icons/battery-full.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/battery-low.tsx
+++ b/src/icons/battery-low.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/battery-medium.tsx
+++ b/src/icons/battery-medium.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/behance-fill.tsx
+++ b/src/icons/behance-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/bell.tsx
+++ b/src/icons/bell.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/bicycle.tsx
+++ b/src/icons/bicycle.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/bitcoin-fill.tsx
+++ b/src/icons/bitcoin-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/block.tsx
+++ b/src/icons/block.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/bluetooth.tsx
+++ b/src/icons/bluetooth.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/boat.tsx
+++ b/src/icons/boat.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/book-close.tsx
+++ b/src/icons/book-close.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/book-open.tsx
+++ b/src/icons/book-open.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/book.tsx
+++ b/src/icons/book.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/bootstrap-fill.tsx
+++ b/src/icons/bootstrap-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/box.tsx
+++ b/src/icons/box.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/briefcase.tsx
+++ b/src/icons/briefcase.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/bug.tsx
+++ b/src/icons/bug.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/cake.tsx
+++ b/src/icons/cake.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/calculator.tsx
+++ b/src/icons/calculator.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/calendar.tsx
+++ b/src/icons/calendar.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/camera.tsx
+++ b/src/icons/camera.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/cart.tsx
+++ b/src/icons/cart.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chat-add.tsx
+++ b/src/icons/chat-add.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chat-approve.tsx
+++ b/src/icons/chat-approve.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chat-bubble.tsx
+++ b/src/icons/chat-bubble.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chat-dots.tsx
+++ b/src/icons/chat-dots.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chat-edit.tsx
+++ b/src/icons/chat-edit.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chat-error.tsx
+++ b/src/icons/chat-error.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chat-question.tsx
+++ b/src/icons/chat-question.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chat-reject.tsx
+++ b/src/icons/chat-reject.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chat-remove.tsx
+++ b/src/icons/chat-remove.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/check-box-fill.tsx
+++ b/src/icons/check-box-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/check-box.tsx
+++ b/src/icons/check-box.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/check-in.tsx
+++ b/src/icons/check-in.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/check.tsx
+++ b/src/icons/check.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chess.tsx
+++ b/src/icons/chess.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chevron-down-small.tsx
+++ b/src/icons/chevron-down-small.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chevron-down.tsx
+++ b/src/icons/chevron-down.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chevron-horizontal.tsx
+++ b/src/icons/chevron-horizontal.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chevron-left-small.tsx
+++ b/src/icons/chevron-left-small.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chevron-left.tsx
+++ b/src/icons/chevron-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chevron-right-small.tsx
+++ b/src/icons/chevron-right-small.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chevron-right.tsx
+++ b/src/icons/chevron-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chevron-up-small.tsx
+++ b/src/icons/chevron-up-small.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chevron-up.tsx
+++ b/src/icons/chevron-up.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/chevron-vertical.tsx
+++ b/src/icons/chevron-vertical.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-alert-fill.tsx
+++ b/src/icons/circle-alert-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-alert.tsx
+++ b/src/icons/circle-alert.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-check-fill.tsx
+++ b/src/icons/circle-check-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-check.tsx
+++ b/src/icons/circle-check.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-chevron-down-fill.tsx
+++ b/src/icons/circle-chevron-down-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-chevron-down.tsx
+++ b/src/icons/circle-chevron-down.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-chevron-left-fill.tsx
+++ b/src/icons/circle-chevron-left-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-chevron-left.tsx
+++ b/src/icons/circle-chevron-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-chevron-right-fill.tsx
+++ b/src/icons/circle-chevron-right-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-chevron-right.tsx
+++ b/src/icons/circle-chevron-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-chevron-up-fill.tsx
+++ b/src/icons/circle-chevron-up-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-chevron-up.tsx
+++ b/src/icons/circle-chevron-up.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-fill.tsx
+++ b/src/icons/circle-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-minus-fill.tsx
+++ b/src/icons/circle-minus-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-minus.tsx
+++ b/src/icons/circle-minus.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-plus-fill.tsx
+++ b/src/icons/circle-plus-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-plus.tsx
+++ b/src/icons/circle-plus.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-triangle-down-fill.tsx
+++ b/src/icons/circle-triangle-down-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-triangle-down.tsx
+++ b/src/icons/circle-triangle-down.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-triangle-left-fill.tsx
+++ b/src/icons/circle-triangle-left-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-triangle-left.tsx
+++ b/src/icons/circle-triangle-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-triangle-right-fill.tsx
+++ b/src/icons/circle-triangle-right-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-triangle-right.tsx
+++ b/src/icons/circle-triangle-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-triangle-up-fill.tsx
+++ b/src/icons/circle-triangle-up-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-triangle-up.tsx
+++ b/src/icons/circle-triangle-up.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-x-fill.tsx
+++ b/src/icons/circle-x-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle-x.tsx
+++ b/src/icons/circle-x.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/circle.tsx
+++ b/src/icons/circle.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/clipboard.tsx
+++ b/src/icons/clipboard.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/clock.tsx
+++ b/src/icons/clock.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/cloud-download.tsx
+++ b/src/icons/cloud-download.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/cloud-upload.tsx
+++ b/src/icons/cloud-upload.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/cloud.tsx
+++ b/src/icons/cloud.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/codepen-fill.tsx
+++ b/src/icons/codepen-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/coffee.tsx
+++ b/src/icons/coffee.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/coin.tsx
+++ b/src/icons/coin.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Ellipse, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/command.tsx
+++ b/src/icons/command.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/computing.tsx
+++ b/src/icons/computing.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/copy.tsx
+++ b/src/icons/copy.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/credit-card-alt1.tsx
+++ b/src/icons/credit-card-alt1.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/credit-card.tsx
+++ b/src/icons/credit-card.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/cross.tsx
+++ b/src/icons/cross.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/crown.tsx
+++ b/src/icons/crown.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/css-fill.tsx
+++ b/src/icons/css-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/cursor.tsx
+++ b/src/icons/cursor.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/cut.tsx
+++ b/src/icons/cut.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dashboard.tsx
+++ b/src/icons/dashboard.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/data.tsx
+++ b/src/icons/data.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Ellipse, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dental.tsx
+++ b/src/icons/dental.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/descending.tsx
+++ b/src/icons/descending.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/desktop-device.tsx
+++ b/src/icons/desktop-device.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/devices.tsx
+++ b/src/icons/devices.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/diamond.tsx
+++ b/src/icons/diamond.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dice-1.tsx
+++ b/src/icons/dice-1.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dice-2.tsx
+++ b/src/icons/dice-2.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dice-3.tsx
+++ b/src/icons/dice-3.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dice-4.tsx
+++ b/src/icons/dice-4.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dice-5.tsx
+++ b/src/icons/dice-5.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dice-6.tsx
+++ b/src/icons/dice-6.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/discord-fill.tsx
+++ b/src/icons/discord-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/django-fill.tsx
+++ b/src/icons/django-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/door.tsx
+++ b/src/icons/door.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dot-grid-fill.tsx
+++ b/src/icons/dot-grid-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dot-grid.tsx
+++ b/src/icons/dot-grid.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/double-check.tsx
+++ b/src/icons/double-check.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/double-sword.tsx
+++ b/src/icons/double-sword.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/download.tsx
+++ b/src/icons/download.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/draft.tsx
+++ b/src/icons/draft.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/drag-horizontal-fill.tsx
+++ b/src/icons/drag-horizontal-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/drag-vertical-fill.tsx
+++ b/src/icons/drag-vertical-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dribbble-fill.tsx
+++ b/src/icons/dribbble-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/dropbox-fill.tsx
+++ b/src/icons/dropbox-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/edit.tsx
+++ b/src/icons/edit.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/enlarge.tsx
+++ b/src/icons/enlarge.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/envelope.tsx
+++ b/src/icons/envelope.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/equal-fill.tsx
+++ b/src/icons/equal-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/equal.tsx
+++ b/src/icons/equal.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/eye-closed.tsx
+++ b/src/icons/eye-closed.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/eye-open.tsx
+++ b/src/icons/eye-open.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/eye-slashed.tsx
+++ b/src/icons/eye-slashed.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/face-happy.tsx
+++ b/src/icons/face-happy.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/face-neutral.tsx
+++ b/src/icons/face-neutral.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/face-sad.tsx
+++ b/src/icons/face-sad.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/face-very-happy.tsx
+++ b/src/icons/face-very-happy.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/face-very-sad.tsx
+++ b/src/icons/face-very-sad.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/face-wink.tsx
+++ b/src/icons/face-wink.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/facebook-fill.tsx
+++ b/src/icons/facebook-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/figma-fill.tsx
+++ b/src/icons/figma-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/file.tsx
+++ b/src/icons/file.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/filter.tsx
+++ b/src/icons/filter.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Ellipse, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/fire.tsx
+++ b/src/icons/fire.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/flag.tsx
+++ b/src/icons/flag.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/flashlight.tsx
+++ b/src/icons/flashlight.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Ellipse, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/folder-add.tsx
+++ b/src/icons/folder-add.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/folder.tsx
+++ b/src/icons/folder.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/fork-left.tsx
+++ b/src/icons/fork-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/fork-right.tsx
+++ b/src/icons/fork-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/frame.tsx
+++ b/src/icons/frame.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/full-screen.tsx
+++ b/src/icons/full-screen.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/game-controller.tsx
+++ b/src/icons/game-controller.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/gatsby-fill.tsx
+++ b/src/icons/gatsby-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/gear.tsx
+++ b/src/icons/gear.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/gift.tsx
+++ b/src/icons/gift.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/github-fill.tsx
+++ b/src/icons/github-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/gitlab-fill.tsx
+++ b/src/icons/gitlab-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/glasses.tsx
+++ b/src/icons/glasses.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/globe.tsx
+++ b/src/icons/globe.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Ellipse, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/google-contained-fill.tsx
+++ b/src/icons/google-contained-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/google-fill.tsx
+++ b/src/icons/google-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/graphql-fill.tsx
+++ b/src/icons/graphql-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/grid.tsx
+++ b/src/icons/grid.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/hammer.tsx
+++ b/src/icons/hammer.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/hand.tsx
+++ b/src/icons/hand.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/hashtag.tsx
+++ b/src/icons/hashtag.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/headphone.tsx
+++ b/src/icons/headphone.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/health.tsx
+++ b/src/icons/health.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/heart.tsx
+++ b/src/icons/heart.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/height.tsx
+++ b/src/icons/height.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/heptagon-fill.tsx
+++ b/src/icons/heptagon-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/heptagon.tsx
+++ b/src/icons/heptagon.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/hexagon-fill.tsx
+++ b/src/icons/hexagon-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/hexagon.tsx
+++ b/src/icons/hexagon.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/history.tsx
+++ b/src/icons/history.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/home-alt1.tsx
+++ b/src/icons/home-alt1.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/home.tsx
+++ b/src/icons/home.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/html-fill.tsx
+++ b/src/icons/html-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/icon.tsx
+++ b/src/icons/icon.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/image.tsx
+++ b/src/icons/image.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/inbox.tsx
+++ b/src/icons/inbox.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/infinite.tsx
+++ b/src/icons/infinite.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/infinity.tsx
+++ b/src/icons/infinity.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/info-fill.tsx
+++ b/src/icons/info-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/info.tsx
+++ b/src/icons/info.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/instagram-fill.tsx
+++ b/src/icons/instagram-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/jar.tsx
+++ b/src/icons/jar.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/javascript-fill.tsx
+++ b/src/icons/javascript-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/jquery-fill.tsx
+++ b/src/icons/jquery-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/key-cap.tsx
+++ b/src/icons/key-cap.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/key.tsx
+++ b/src/icons/key.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/language.tsx
+++ b/src/icons/language.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/laptop-device.tsx
+++ b/src/icons/laptop-device.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/leaf.tsx
+++ b/src/icons/leaf.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/lifesaver.tsx
+++ b/src/icons/lifesaver.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import {
   Circle as _Circle,
   ClipPath,

--- a/src/icons/light-bulb.tsx
+++ b/src/icons/light-bulb.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/link-chain.tsx
+++ b/src/icons/link-chain.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/link-off.tsx
+++ b/src/icons/link-off.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/link-on.tsx
+++ b/src/icons/link-on.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/link-out.tsx
+++ b/src/icons/link-out.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/linkedInV1-fill.tsx
+++ b/src/icons/linkedInV1-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/linkedInV2-fill.tsx
+++ b/src/icons/linkedInV2-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/linkedin-V1-fill.tsx
+++ b/src/icons/linkedin-V1-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/linkedin-V2-fill.tsx
+++ b/src/icons/linkedin-V2-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/linkedin-box-fill.tsx
+++ b/src/icons/linkedin-box-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/linkedin-fill.tsx
+++ b/src/icons/linkedin-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/location.tsx
+++ b/src/icons/location.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/lock-off.tsx
+++ b/src/icons/lock-off.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/lock-on.tsx
+++ b/src/icons/lock-on.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/map.tsx
+++ b/src/icons/map.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/mastodon-fill.tsx
+++ b/src/icons/mastodon-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/medium-fill.tsx
+++ b/src/icons/medium-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/mention.tsx
+++ b/src/icons/mention.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/microphone.tsx
+++ b/src/icons/microphone.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/miniplayer.tsx
+++ b/src/icons/miniplayer.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/minus.tsx
+++ b/src/icons/minus.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/mobile-device.tsx
+++ b/src/icons/mobile-device.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/money.tsx
+++ b/src/icons/money.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/moon-fill.tsx
+++ b/src/icons/moon-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/moon.tsx
+++ b/src/icons/moon.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/more-horizontal-fill.tsx
+++ b/src/icons/more-horizontal-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/more-vertical-fill.tsx
+++ b/src/icons/more-vertical-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/music-album-fill.tsx
+++ b/src/icons/music-album-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/music-album.tsx
+++ b/src/icons/music-album.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/music-note.tsx
+++ b/src/icons/music-note.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/music.tsx
+++ b/src/icons/music.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/network.tsx
+++ b/src/icons/network.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/newspaper.tsx
+++ b/src/icons/newspaper.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/nextjs-fill.tsx
+++ b/src/icons/nextjs-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/node-fill.tsx
+++ b/src/icons/node-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/normal-screen.tsx
+++ b/src/icons/normal-screen.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/npm-fill.tsx
+++ b/src/icons/npm-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/octagon-fill.tsx
+++ b/src/icons/octagon-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/octagon.tsx
+++ b/src/icons/octagon.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/octocat-fill.tsx
+++ b/src/icons/octocat-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/open-envelope.tsx
+++ b/src/icons/open-envelope.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/oval.tsx
+++ b/src/icons/oval.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Ellipse, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/panel-bottom.tsx
+++ b/src/icons/panel-bottom.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/panel-left.tsx
+++ b/src/icons/panel-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/panel-right.tsx
+++ b/src/icons/panel-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/panel-split-column.tsx
+++ b/src/icons/panel-split-column.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/panel-split-row.tsx
+++ b/src/icons/panel-split-row.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/panel-split.tsx
+++ b/src/icons/panel-split.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/panel-top.tsx
+++ b/src/icons/panel-top.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/paper-airplane.tsx
+++ b/src/icons/paper-airplane.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/paper.tsx
+++ b/src/icons/paper.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/parallelogram.tsx
+++ b/src/icons/parallelogram.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pause.tsx
+++ b/src/icons/pause.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pencil.tsx
+++ b/src/icons/pencil.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pentagon-fill.tsx
+++ b/src/icons/pentagon-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pentagon.tsx
+++ b/src/icons/pentagon.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/people-group.tsx
+++ b/src/icons/people-group.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/people-multiple.tsx
+++ b/src/icons/people-multiple.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/percentage.tsx
+++ b/src/icons/percentage.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/person-add.tsx
+++ b/src/icons/person-add.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/person-check.tsx
+++ b/src/icons/person-check.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/person-cross.tsx
+++ b/src/icons/person-cross.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/person.tsx
+++ b/src/icons/person.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/phone.tsx
+++ b/src/icons/phone.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/php-fill.tsx
+++ b/src/icons/php-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pin.tsx
+++ b/src/icons/pin.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pinterest-fill.tsx
+++ b/src/icons/pinterest-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/plane-fill.tsx
+++ b/src/icons/plane-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/plane.tsx
+++ b/src/icons/plane.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/planet.tsx
+++ b/src/icons/planet.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/plant.tsx
+++ b/src/icons/plant.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/play.tsx
+++ b/src/icons/play.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/plus.tsx
+++ b/src/icons/plus.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pointer-down-fill.tsx
+++ b/src/icons/pointer-down-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pointer-hand.tsx
+++ b/src/icons/pointer-hand.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pointer-left-fill.tsx
+++ b/src/icons/pointer-left-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pointer-right-fill.tsx
+++ b/src/icons/pointer-right-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pointer-up-fill.tsx
+++ b/src/icons/pointer-up-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/pointing-up.tsx
+++ b/src/icons/pointing-up.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/postgresql-fill.tsx
+++ b/src/icons/postgresql-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/price-cut.tsx
+++ b/src/icons/price-cut.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/product-hunt-fill.tsx
+++ b/src/icons/product-hunt-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/python-fill.tsx
+++ b/src/icons/python-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/question-fill.tsx
+++ b/src/icons/question-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/question.tsx
+++ b/src/icons/question.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/radio-fill.tsx
+++ b/src/icons/radio-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/radio.tsx
+++ b/src/icons/radio.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/radish.tsx
+++ b/src/icons/radish.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/react-fill.tsx
+++ b/src/icons/react-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/receipt.tsx
+++ b/src/icons/receipt.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/reciept.tsx
+++ b/src/icons/reciept.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/reddit-fill.tsx
+++ b/src/icons/reddit-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/reduce.tsx
+++ b/src/icons/reduce.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/redux-fill.tsx
+++ b/src/icons/redux-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/ribbon.tsx
+++ b/src/icons/ribbon.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/rock-on.tsx
+++ b/src/icons/rock-on.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/rss.tsx
+++ b/src/icons/rss.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sass-fill.tsx
+++ b/src/icons/sass-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/save.tsx
+++ b/src/icons/save.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/schedule.tsx
+++ b/src/icons/schedule.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/scissor.tsx
+++ b/src/icons/scissor.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/search.tsx
+++ b/src/icons/search.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/send.tsx
+++ b/src/icons/send.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/settings-horizontal.tsx
+++ b/src/icons/settings-horizontal.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/settings-vertical.tsx
+++ b/src/icons/settings-vertical.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/share-box.tsx
+++ b/src/icons/share-box.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/shield.tsx
+++ b/src/icons/shield.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/shipping-box-v1.tsx
+++ b/src/icons/shipping-box-v1.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/shipping-box-v2.tsx
+++ b/src/icons/shipping-box-v2.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/shopping-bag.tsx
+++ b/src/icons/shopping-bag.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sidebar-left.tsx
+++ b/src/icons/sidebar-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sidebar-right.tsx
+++ b/src/icons/sidebar-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sign-out.tsx
+++ b/src/icons/sign-out.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/slack-fill.tsx
+++ b/src/icons/slack-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/slice.tsx
+++ b/src/icons/slice.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/snapchat-fill.tsx
+++ b/src/icons/snapchat-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sort.tsx
+++ b/src/icons/sort.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sound-down.tsx
+++ b/src/icons/sound-down.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sound-off.tsx
+++ b/src/icons/sound-off.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sound-on.tsx
+++ b/src/icons/sound-on.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sound-up.tsx
+++ b/src/icons/sound-up.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/soundcloud-fill.tsx
+++ b/src/icons/soundcloud-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sparkles.tsx
+++ b/src/icons/sparkles.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/spotify-fill.tsx
+++ b/src/icons/spotify-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/square-fill.tsx
+++ b/src/icons/square-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/square.tsx
+++ b/src/icons/square.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/stack-overflow-fill.tsx
+++ b/src/icons/stack-overflow-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/star.tsx
+++ b/src/icons/star.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/statistic-down.tsx
+++ b/src/icons/statistic-down.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/statistic-up.tsx
+++ b/src/icons/statistic-up.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/stop-fill.tsx
+++ b/src/icons/stop-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/stop.tsx
+++ b/src/icons/stop.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sun-fill.tsx
+++ b/src/icons/sun-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sun.tsx
+++ b/src/icons/sun.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/sword.tsx
+++ b/src/icons/sword.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/tablet-device.tsx
+++ b/src/icons/tablet-device.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/tag.tsx
+++ b/src/icons/tag.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/telegram-fill.tsx
+++ b/src/icons/telegram-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/telescope.tsx
+++ b/src/icons/telescope.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/tetragon-fill.tsx
+++ b/src/icons/tetragon-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/tetragon.tsx
+++ b/src/icons/tetragon.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/text-align-center.tsx
+++ b/src/icons/text-align-center.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/text-align-justified.tsx
+++ b/src/icons/text-align-justified.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/text-align-left.tsx
+++ b/src/icons/text-align-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/text-align-right.tsx
+++ b/src/icons/text-align-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/threads-fill.tsx
+++ b/src/icons/threads-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/three-line-horizontal.tsx
+++ b/src/icons/three-line-horizontal.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/three-line-vertical.tsx
+++ b/src/icons/three-line-vertical.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/thumbs-down.tsx
+++ b/src/icons/thumbs-down.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/thumbs-up.tsx
+++ b/src/icons/thumbs-up.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/thunder.tsx
+++ b/src/icons/thunder.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/ticket.tsx
+++ b/src/icons/ticket.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/tiktok-fill.tsx
+++ b/src/icons/tiktok-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/toggle-off-fill.tsx
+++ b/src/icons/toggle-off-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/toggle-off.tsx
+++ b/src/icons/toggle-off.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/toggle-on-fill.tsx
+++ b/src/icons/toggle-on-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/toggle-on.tsx
+++ b/src/icons/toggle-on.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/togo-cup.tsx
+++ b/src/icons/togo-cup.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/trash-bin.tsx
+++ b/src/icons/trash-bin.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Ellipse, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/trash-can.tsx
+++ b/src/icons/trash-can.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-alert-fill.tsx
+++ b/src/icons/triangle-alert-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-alert.tsx
+++ b/src/icons/triangle-alert.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-down-fill.tsx
+++ b/src/icons/triangle-down-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-down.tsx
+++ b/src/icons/triangle-down.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-fill.tsx
+++ b/src/icons/triangle-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-left-fill.tsx
+++ b/src/icons/triangle-left-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-left.tsx
+++ b/src/icons/triangle-left.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-right-fill.tsx
+++ b/src/icons/triangle-right-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-right.tsx
+++ b/src/icons/triangle-right.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-up-fill.tsx
+++ b/src/icons/triangle-up-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle-up.tsx
+++ b/src/icons/triangle-up.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/triangle.tsx
+++ b/src/icons/triangle.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/trophy.tsx
+++ b/src/icons/trophy.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/truck.tsx
+++ b/src/icons/truck.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/tumblr-fill.tsx
+++ b/src/icons/tumblr-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/twitch-fill.tsx
+++ b/src/icons/twitch-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/twitter-fill.tsx
+++ b/src/icons/twitter-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/two-line-horizontal.tsx
+++ b/src/icons/two-line-horizontal.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/two-line-vertical.tsx
+++ b/src/icons/two-line-vertical.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/typescript-fill.tsx
+++ b/src/icons/typescript-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/umbrella.tsx
+++ b/src/icons/umbrella.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/unsplash-fill.tsx
+++ b/src/icons/unsplash-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/utensils.tsx
+++ b/src/icons/utensils.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/vape-kit.tsx
+++ b/src/icons/vape-kit.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/vercel-fill.tsx
+++ b/src/icons/vercel-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/victory-hand.tsx
+++ b/src/icons/victory-hand.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/video.tsx
+++ b/src/icons/video.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Rect, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/vimeo-fill.tsx
+++ b/src/icons/vimeo-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/vk-fill.tsx
+++ b/src/icons/vk-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/vr-ar.tsx
+++ b/src/icons/vr-ar.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/vscode-fill.tsx
+++ b/src/icons/vscode-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/vue-fill.tsx
+++ b/src/icons/vue-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/wallet.tsx
+++ b/src/icons/wallet.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/watch-device.tsx
+++ b/src/icons/watch-device.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/water.tsx
+++ b/src/icons/water.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/whatsapp-fill.tsx
+++ b/src/icons/whatsapp-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/width.tsx
+++ b/src/icons/width.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/wifi.tsx
+++ b/src/icons/wifi.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Circle as _Circle, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/wine-glass.tsx
+++ b/src/icons/wine-glass.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/x-fill.tsx
+++ b/src/icons/x-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/x-small.tsx
+++ b/src/icons/x-small.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/yarn-fill.tsx
+++ b/src/icons/yarn-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/yelp-fill.tsx
+++ b/src/icons/yelp-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/youtube-fill.tsx
+++ b/src/icons/youtube-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/zoom-fill.tsx
+++ b/src/icons/zoom-fill.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { ClipPath, Defs, G, Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/zoom-in.tsx
+++ b/src/icons/zoom-in.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/src/icons/zoom-out.tsx
+++ b/src/icons/zoom-out.tsx
@@ -1,5 +1,5 @@
 import type { NamedExoticComponent } from "react";
-import { memo } from "react";
+import React, { memo } from "react";
 import { Path, Svg } from "react-native-svg";
 import type { IconProps } from "../types/icons/helpers-icon";
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,15 +2,13 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "outDir": "lib/typescript",
-    "outFile": "lib/typescript/index.d.ts",
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "noEmit": false,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": false,
-    "verbatimModuleSyntax": false
+    "allowImportingTsExtensions": false
   },
   "exclude": ["node_modules", "lib"],
   "include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
+    "jsx": "react-native",
     "lib": ["ESNext"],
     "module": "ESNext",
     "moduleResolution": "Bundler",


### PR DESCRIPTION
- **Revert "guillaume/tas 176 reduce number of typescripts files for packaging (#10)"**
  This reverts commit 0ec50db8d859f8bd76fbcdd80372e33ae5d26a8b.
  

- **chore(scripts): use  to run  in the  script**
  

- **chore(tsconfig): uses  for  instead of**
  

- **fix(icons): fixes script for building icons**
  This uses `fs.mkdirSync` instead of `fs.mkdir` to create directories in
  `src/`. So now, even if the directories does not exists, the scripts is
  waiting the creation of the directories before building icons.
  